### PR TITLE
fix(docs): add missing parenthesis

### DIFF
--- a/docs/concepts/state.md
+++ b/docs/concepts/state.md
@@ -242,7 +242,7 @@ export class ZooState {
    */
   @Action(FeedAnimals)
   feedAnimals2({ dispatch }: StateContext<ZooStateModel>, { payload }: FeedAnimals) {
-    return this.animalService.feed(payload).pipe(map() => dispatch(TakeAnimalsOutside));
+    return this.animalService.feed(payload).pipe(map(() => dispatch(TakeAnimalsOutside));
   }
 }
 ```


### PR DESCRIPTION
Addded missing parenthesis to the `map` function