### PR TITLE
feat: add overloading to select method in Store

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -50,6 +50,8 @@ export class Store {
   /**
    * Selects a slice of data from the store.
    */
+  select<T>(selector: (state: any) => T): Observable<T>;
+  select(selector: string | any): Observable<any>;
   select(selector: any): Observable<any> {
     if (selector[META_KEY] && selector[META_KEY].path) {
       const getter = fastPropGetter(selector[META_KEY].path.split('.'));


### PR DESCRIPTION
Hey!

I'm currently evaluating using ngxs for a large Angular app and so far it looks great. I'm particularly interested in the type-safety of selecting data from the store and I think this improves it for the `store.select()` approach.

A simple example:
```ts
interface User {
  name: string;
}

interface State {
  users: User[];
}

// this will type check but is wrong as actually userNames$ will be Observable<number>
const userNames$: Observable<string> = store.select((state: State) => state.users.length);
```

With this additional function signature I get this error:
```
[ts]
Type 'Observable<number>' is not assignable to type 'Observable<string>'.
  Type 'number' is not assignable to type 'string'.
```